### PR TITLE
LSFDRMAA_MAX_QUEUE_SKEW, 30 -> 300

### DIFF
--- a/lsf_drmaa/job.c
+++ b/lsf_drmaa/job.c
@@ -148,7 +148,7 @@ lsfdrmaa_job_control( fsd_job_t *self, int action )
 	fsd_log_return(( "" ));
 }
 
-#define LSFDRMAA_MAX_QUEUE_SKEW (30)
+#define LSFDRMAA_MAX_QUEUE_SKEW (300)
 
 static void 
 lsfdrmaa_job_on_missing(fsd_job_t *self)


### PR DESCRIPTION
See my comment on commit: https://github.com/PlatformLSF/lsf-drmaa/commit/025f9c49af48e410dc0ab0b9c611c42935dc09eb . On our cluster jobs were failing due to a lag longer than 30 seconds. Increasing this to 300 prevented LSF-DRMAA from spuriously killing jobs. In the initial commit this define had a value of 500.

Thanks.
