### PR TITLE
support bsub -app and -Lp option by config them in lsf_drmaa.conf

### DIFF
--- a/lsf_drmaa/native.rl
+++ b/lsf_drmaa/native.rl
@@ -94,7 +94,7 @@ lsfdrmaa_native_parse( const char *native_spec, struct submit *req )
 	argument = char+ | char* (quoted_string char*)+;
 	short_with_arg = ([LcCFWkPGgqRmnJbtuUMDSvfa] | 'i' 's'? | [oe] 'o'?
 		| 'w' [at]? | 'E' 'p'? | 'sp' | 'sla' | 'ext' 'sched'?
-		| 'jsdl' '_strict'? | 'We' | 'cwd' | 'ar')
+		| 'jsdl' '_strict'? | 'We' | 'cwd' | 'ar' | 'app' | 'Lp' )
 		>opt_begin %opt_end;
 	short_without_arg = ([xHNBK] | 'r' 'n'? | 'I' [ps]? | 'Zs')
 		>opt_begin %opt_end;


### PR DESCRIPTION
add -app or -Lp in lsf_drmaa.conf

```
# cat lsf_drmaa.conf
job_categories: {
  #default: "-B",
  app:"-app app1",
  lp:"-Lp lsproj1",
},[root@yanlidev1 sample]# emacs lsf_drmaa.conf
[root@yanlidev1 sample]# cat lsf_drmaa.conf
job_categories: {
  #default: "-B",
  app:"-app app1",
  lp:"-Lp lsproj1",
},
```
add the category attribute by calling drmaa_set_attribute() in sample/sub.c before calling drmaa_run_job()
```
  drmaa_set_attribute(jt, DRMAA_JOB_CATEGORY, "app", NULL, 0);
```

compile and running sub.c:

```
t #7d1a [     0.00] -> drmaa_set_attribute(jt=0x79f1a0, name='drmaa_job_category', value='app')
t #7d1a [     0.00] -> fsd_template_set_attr(drmaa_job_category=app)
t #7d1a [     0.00] <- drmaa_set_attribute =0
t #7d1a [     0.00] -> drmaa_run_job(jt=0x79f1a0)
t #7d1b [     0.01] -> fsd_job_set_get(job_id=6947)
t #7d1b [     0.01] <- fsd_job_set_get(job_id=6947) =NULL
t #7d1b [     0.01] -> fsd_job_set_get(job_id=6948)
t #7d1b [     0.01] <- fsd_job_set_get(job_id=6948) =NULL
t #7d1b [     0.01] -> fsd_job_set_get(job_id=6949)
t #7d1b [     0.01] <- fsd_job_set_get(job_id=6949) =NULL
t #7d1b [     0.01] -> fsd_job_set_get(job_id=6950)
t #7d1b [     0.01] <- fsd_job_set_get(job_id=6950) =NULL
t #7d1b [     0.01] -> fsd_job_set_get(job_id=6951)
t #7d1b [     0.01] <- fsd_job_set_get(job_id=6951) =NULL
t #7d1b [     0.01] -> fsd_job_set_get(job_id=6952)
t #7d1b [     0.01] <- fsd_job_set_get(job_id=6952) =NULL
t #7d1b [     0.01] -> fsd_job_set_get(job_id=6953)
t #7d1b [     0.01] <- fsd_job_set_get(job_id=6953) =NULL
t #7d1b [     0.01] <- lsfdrmaa_session_update_all_jobs_status
d #7d1a [     0.01]  * native parse: -app 'app1'
d #7d1a [     0.01]  * characters parsed=9, left=0
d #7d1a [     0.01]  |   drmaa_output_path: :$drmaa_hd_ph$/DRMAA_JOB -> /root/DRMAA_JOB
d #7d1a [     0.01]  |   command: "exec" "sleep" "20"
d #7d1a [     0.01]  |   numProcessors: 0
d #7d1a [     0.01]  |   maxNumProcessors: 0
d #7d1a [     0.01]  |   outFile: /root/DRMAA_JOB [overwrite]
d #7d1a [     0.01]  |   mailUser: notexistent
d #7d1a [     0.01]  |   jsdlDoc: (null)
d #7d1a [     0.01]  |   cwd: /root
Job <6954> is submitted to default queue <normal>.
```
